### PR TITLE
saída da comunidade + padronização de estilos

### DIFF
--- a/meuApp/app/detalhes-comunidade.tsx
+++ b/meuApp/app/detalhes-comunidade.tsx
@@ -145,7 +145,46 @@ export default function DetalhesComunidadeScreen() {
     }
   };
 
-  const handleLeaveCommunity = () => {
+  const handleLeaveCommunity = async () => {
+    try {
+      setLoading(true);
+      const result = await leaveComunidade(comunidadeId);
+      setLoading(false);
+      if (result.success) {
+        Toast.show({
+          type: "success",
+          text1: "Pronto",
+          text2: "Você saiu da comunidade.",
+          visibilityTime: 2000,
+          autoHide: true,
+          topOffset: 50,
+        });
+        setMembersData((prev) => prev.filter((m) => m.id !== user.uid));
+        setTimeout(() => {
+          try { router.replace("/comunidades"); } catch {}
+        }, 700);
+      } else {
+        Toast.show({
+          type: "error",
+          text1: "Erro ao sair",
+          text2: result.error || "Não foi possível sair da comunidade.",
+          visibilityTime: 3000,
+          autoHide: true,
+          topOffset: 50,
+        });
+      }
+    } catch (e) {
+      setLoading(false);
+      Toast.show({
+        type: "error",
+        text1: "Erro inesperado",
+        text2: "Tente novamente mais tarde.",
+        visibilityTime: 3000,
+        autoHide: true,
+        topOffset: 50,
+      });
+    }
+    return;
     // Feedback imediato para confirmar clique
     try {
       Toast.show({

--- a/meuApp/app/detalhes-comunidade.tsx
+++ b/meuApp/app/detalhes-comunidade.tsx
@@ -26,7 +26,16 @@ export default function DetalhesComunidadeScreen() {
   const router = useRouter();
   const params = useLocalSearchParams();
   const { user } = useAuth();
-  const { comunidades, isOwner, updateComunidade, deleteComunidade, leaveComunidade, removeMember } = useComunidades();
+  const {
+    comunidades,
+    isOwner,
+    isMember,
+    updateComunidade,
+    deleteComunidade,
+    joinComunidade,
+    leaveComunidade,
+    removeMember,
+  } = useComunidades();
 
   // Buscar comunidade pelos parâmetros
   const comunidadeId = params.id as string;
@@ -95,6 +104,7 @@ export default function DetalhesComunidadeScreen() {
   }
 
   const isAdmin = isOwner(comunidadeId, user.uid);
+  const userIsMember = isMember(comunidadeId, user.uid);
 
   const handleSaveChanges = async () => {
     if (!nome.trim() || !descricao.trim()) {
@@ -217,6 +227,32 @@ export default function DetalhesComunidadeScreen() {
         },
       ]
     );
+  };
+
+  const handleJoinCommunity = async () => {
+    setLoading(true);
+    const result = await joinComunidade(comunidadeId);
+    setLoading(false);
+
+    if (result.success) {
+      Toast.show({
+        type: "success",
+        text1: "Sucesso",
+        text2: "Você entrou na comunidade",
+        visibilityTime: 3000,
+        autoHide: true,
+        topOffset: 50,
+      });
+    } else {
+      Toast.show({
+        type: "error",
+        text1: "Erro",
+        text2: result.error || "Erro ao entrar na comunidade",
+        visibilityTime: 3000,
+        autoHide: true,
+        topOffset: 50,
+      });
+    }
   };
 
   const handleRemoveMember = (memberId: string, memberName: string) => {
@@ -410,7 +446,7 @@ export default function DetalhesComunidadeScreen() {
         <View style={styles.section}>
           <Text style={styles.sectionTitle}>Ações</Text>
 
-          {!isAdmin && (
+          {!isAdmin && userIsMember && (
             <TouchableOpacity
               style={styles.actionButton}
               onPress={handleLeaveCommunity}
@@ -419,6 +455,16 @@ export default function DetalhesComunidadeScreen() {
               <Text style={[styles.actionText, { color: "#E63946" }]}>
                 Sair da comunidade
               </Text>
+            </TouchableOpacity>
+          )}
+
+          {!isAdmin && !userIsMember && (
+            <TouchableOpacity
+              style={styles.actionButton}
+              onPress={handleJoinCommunity}
+            >
+              <Ionicons name="log-in-outline" size={24} color="#2E7D32" />
+              <Text style={[styles.actionText, { color: "#2E7D32" }]}>Entrar na comunidade</Text>
             </TouchableOpacity>
           )}
 

--- a/meuApp/app/detalhes-comunidade.tsx
+++ b/meuApp/app/detalhes-comunidade.tsx
@@ -169,8 +169,10 @@ export default function DetalhesComunidadeScreen() {
                 topOffset: 50,
               });
               // Voltar para a tela de comunidades após sair
-              router.back();
-              router.back();
+              setMembersData((prev) => prev.filter((m) => m.id !== user.uid));
+              setTimeout(() => {
+                try { router.replace("/comunidades"); } catch {}
+              }, 600);
             } else {
               Toast.show({
                 type: "error",
@@ -450,6 +452,7 @@ export default function DetalhesComunidadeScreen() {
             <TouchableOpacity
               style={styles.actionButton}
               onPress={handleLeaveCommunity}
+              disabled={loading}
             >
               <Ionicons name="exit-outline" size={24} color="#E63946" />
               <Text style={[styles.actionText, { color: "#E63946" }]}>
@@ -462,6 +465,7 @@ export default function DetalhesComunidadeScreen() {
             <TouchableOpacity
               style={styles.actionButton}
               onPress={handleJoinCommunity}
+              disabled={loading}
             >
               <Ionicons name="log-in-outline" size={24} color="#2E7D32" />
               <Text style={[styles.actionText, { color: "#2E7D32" }]}>Entrar na comunidade</Text>

--- a/meuApp/app/detalhes-comunidade.tsx
+++ b/meuApp/app/detalhes-comunidade.tsx
@@ -146,6 +146,17 @@ export default function DetalhesComunidadeScreen() {
   };
 
   const handleLeaveCommunity = () => {
+    // Feedback imediato para confirmar clique
+    try {
+      Toast.show({
+        type: "info",
+        text1: "Sair da comunidade",
+        text2: "Abrindo confirmação...",
+        visibilityTime: 1200,
+        autoHide: true,
+        topOffset: 50,
+      });
+    } catch {}
     Alert.alert(
       "Sair da comunidade",
       "Tem certeza que deseja sair desta comunidade?",
@@ -452,7 +463,6 @@ export default function DetalhesComunidadeScreen() {
             <TouchableOpacity
               style={styles.actionButton}
               onPress={handleLeaveCommunity}
-              disabled={loading}
             >
               <Ionicons name="exit-outline" size={24} color="#E63946" />
               <Text style={[styles.actionText, { color: "#E63946" }]}>


### PR DESCRIPTION
- Implementa saída imediata com toast “Você saiu da comunidade.”
- Remove membro local e navega de volta após breve delay
- Exibe “Sair” só para membros e “Entrar” para não‑membros
- Padroniza fontes/cores da aba Progresso seguindo Perfil
- Docs: adiciona nota em docs/ATUALIZACOES.md