### PR TITLE
Remover o ícone de mais (+) do campo de mensagens da comunidade

### DIFF
--- a/meuApp/app/chat-comunidade.tsx
+++ b/meuApp/app/chat-comunidade.tsx
@@ -128,9 +128,6 @@ export default function ChatComunidadeScreen() {
 
       {/* Input de mensagem */}
       <View style={styles.inputContainer}>
-        <TouchableOpacity style={styles.attachButton}>
-          <Ionicons name="add-circle" size={28} color="#2E7D32" />
-        </TouchableOpacity>
         <TextInput
           style={styles.input}
           placeholder="Digite uma mensagem..."
@@ -245,10 +242,7 @@ const styles = StyleSheet.create({
     borderTopWidth: 1,
     borderTopColor: "#E9ECEF",
   },
-  attachButton: {
-    marginRight: 8,
-    marginBottom: 8,
-  },
+  
   input: {
     flex: 1,
     backgroundColor: "#F8F9FA",


### PR DESCRIPTION
Esta solicitação de pull remove o ícone de adição "+" não utilizado do campo de entrada de mensagens do chat da comunidade para evitar confusão e toques acidentais.

Alterações:

- Remoção do atributo TouchableOpacity com o nome "add-circle" do ícone na área de entrada.
- Remoção do estilo não utilizado do botão attachButton.